### PR TITLE
Fix the Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,16 @@
-FROM alpine:latest
+FROM debian:latest
 
-# --upgrade-strategy=eager is because there exist older versions of urllib that have a bug that breaks retries
-RUN apk --no-cache add python py-pip python3 && \
-    python -m pip install --upgrade --upgrade-strategy=eager pip stored>=0.0.29 && \
-    python3 -m ensurepip && \
-    python3 -m pip install --upgrade --upgrade-strategy=eager pip stored>=0.0.29
+# --upgrade-strategy=eager is because apparently the version of urllib that ships in stable Debian has a bug that breaks retries
+RUN apt-get -y update && \
+    apt-get -y install python-pip python3-pip && \
+    apt-get -y clean && \
+    pip2 install --upgrade --upgrade-strategy=eager pip stored && \
+    pip3 install --upgrade --upgrade-strategy=eager pip stored
 
 # we install these packages at runtime in the entrypoint, but might as well fetch the latest version into the container
 RUN mkdir /pip && \
-    python -m pip download -d /pip tensorflow keras h5py model-converters && \
-    python3 -m pip download -d /pip tensorflow keras h5py model-converters
+    pip2 download -d /pip tensorflow keras h5py model-converters && \
+    pip3 download -d /pip tensorflow keras h5py model-converters
 # note: don't install model-converters here, since it declares a dependency on tensorflow and keras (so those will be installed too)
 #       which is a waste of space since they get reinstalled in the entrypoint
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='model-converters',
-    version='0.0.11',
+    version='0.0.12',
     description='Tools for converting Keras models for use with other ML frameworks.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',


### PR DESCRIPTION
Tensorflow actually requires glibc (Alpine uses musl), so this switches back to Debian, ~but testing because of https://github.com/triagemd/model-converters/pull/21#issuecomment-351180285~