### PR TITLE
Set LC_ALL and LANG env to C.UTF-8

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,9 @@ RUN mkdir /pip && \
 # note: don't install model-converters here, since it declares a dependency on tensorflow and keras (so those will be installed too)
 #       which is a waste of space since they get reinstalled in the entrypoint
 
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
 ADD entrypoint.sh /opt/
 
 CMD ["/opt/entrypoint.sh"]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='model-converters',
-    version='0.0.12',
+    version='0.0.13',
     description='Tools for converting Keras models for use with other ML frameworks.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',


### PR DESCRIPTION
```
latest: Pulling from triage/model-converter
723254a2c089: Already exists
1f3a66d2ced8: Pulling fs layer
5e5c4ac9f634: Pulling fs layer
9e4e3f643ef1: Pulling fs layer
9e4e3f643ef1: Verifying Checksum
9e4e3f643ef1: Download complete
1f3a66d2ced8: Verifying Checksum
1f3a66d2ced8: Download complete
5e5c4ac9f634: Verifying Checksum
5e5c4ac9f634: Download complete
1f3a66d2ced8: Pull complete
5e5c4ac9f634: Pull complete
9e4e3f643ef1: Pull complete
Digest: sha256:a683d1eca5dc821ac7dadf8c2094bed5d29dd4537815759955c889e6bec12c7b
Status: Downloaded newer image for triage/model-converter:latest
Requirement already up-to-date: pip in /usr/lib/python3/dist-packages
Collecting tensorflow==1.3
  Downloading tensorflow-1.3.0-cp35-cp35m-manylinux1_x86_64.whl (43.1MB)
Collecting keras==2.0.8
  Downloading Keras-2.0.8-py2.py3-none-any.whl (276kB)
Collecting h5py
Collecting model-converters
  Downloading model_converters-0.0.12-py2.py3-none-any.whl
Collecting numpy>=1.11.0 (from tensorflow==1.3)
Requirement already satisfied: wheel>=0.26 in /usr/lib/python3/dist-packages (from tensorflow==1.3)
Requirement already satisfied: six>=1.10.0 in /usr/local/lib/python3.5/dist-packages (from tensorflow==1.3)
Collecting tensorflow-tensorboard<0.2.0,>=0.1.0 (from tensorflow==1.3)
  Downloading tensorflow_tensorboard-0.1.8-py3-none-any.whl (1.6MB)
Requirement already satisfied: protobuf>=3.3.0 in /usr/local/lib/python3.5/dist-packages (from tensorflow==1.3)
Collecting scipy>=0.14 (from keras==2.0.8)
Collecting pyyaml (from keras==2.0.8)
Collecting keras-model-specs (from model-converters)
  Downloading keras_model_specs-0.0.15-py2.py3-none-any.whl
Collecting werkzeug>=0.11.10 (from tensorflow-tensorboard<0.2.0,>=0.1.0->tensorflow==1.3)
Collecting bleach==1.5.0 (from tensorflow-tensorboard<0.2.0,>=0.1.0->tensorflow==1.3)
Collecting markdown>=2.6.8 (from tensorflow-tensorboard<0.2.0,>=0.1.0->tensorflow==1.3)
Collecting html5lib==0.9999999 (from tensorflow-tensorboard<0.2.0,>=0.1.0->tensorflow==1.3)
Requirement already satisfied: setuptools in /usr/local/lib/python3.5/dist-packages (from protobuf>=3.3.0->tensorflow==1.3)
Collecting Pillow (from keras-model-specs->model-converters)
Collecting olefile (from Pillow->keras-model-specs->model-converters)
Building wheels for collected packages: pyyaml, markdown, html5lib, olefile
  Running setup.py bdist_wheel for pyyaml: started
  Running setup.py bdist_wheel for pyyaml: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/2d/db/91/838b68124182a6063e87738e098e3aeacd1f12f4a459d21eb3
  Running setup.py bdist_wheel for markdown: started
  Running setup.py bdist_wheel for markdown: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/cf/c2/23/035e162adb604b53bdfa687670bc6c3acb12e2184301840c0a
  Running setup.py bdist_wheel for html5lib: started
  Running setup.py bdist_wheel for html5lib: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/26/c9/45/0b674be411b11067bfd2b62cb8e0d0a21ac1164f2ea82b0573
  Running setup.py bdist_wheel for olefile: started
  Running setup.py bdist_wheel for olefile: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/61/a0/d3/47bb74281c6c8d85f33e6fbbce37d9dc60553a86c99729ee13
Successfully built pyyaml markdown html5lib olefile
Installing collected packages: numpy, werkzeug, html5lib, bleach, markdown, tensorflow-tensorboard, tensorflow, scipy, pyyaml, keras, h5py, olefile, Pillow, keras-model-specs, model-converters
Successfully installed Pillow-4.3.0 bleach-1.5.0 h5py-2.7.1 html5lib-0.9999999 keras-2.0.8 keras-model-specs-0.0.15 markdown-2.6.10 model-converters-0.0.12 numpy-1.13.3 olefile-0.44 pyyaml-3.12 scipy-1.0.0 tensorflow-1.3.0 tensorflow-tensorboard-0.1.8 werkzeug-0.13
Traceback (most recent call last):
  File "/usr/local/bin/stored", line 11, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 676, in main
    _verify_python3_env()
  File "/usr/local/lib/python3.5/dist-packages/click/_unicodefun.py", line 118, in _verify_python3_env
    'for mitigation steps.' + extra)
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment.  Consult http://click.pocoo.org/python3/for mitigation steps.

This system supports the C.UTF-8 locale which is recommended.
You might be able to resolve your issue by exporting the
following environment variables:

    export LC_ALL=C.UTF-8
    export LANG=C.UTF-8
```