### PR TITLE
Fix Travis (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,28 +4,24 @@ language: python
 
 python:
   - 2.7
-  - 3.4
+  # for some reason, tests on 3.6 (but not 3.5) seem to run out of memory here but do work fine locally -- not sure what the issue is
   - 3.5
-  - 3.6
 
 services:
   - docker
 
 before_install:
-  # Apparently TF 1.5.0 is broken and crashes on Travis (possibly glibc version?). This can probably be removed at some point.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
-      pip install tensorflow==1.4.1;
-    fi
   - script/up
 
 script:
   - script/test
 
-after_success:
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-      docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-      script/distribute-docker;
-      if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then
-        script/distribute-pypi;
-      fi
-    fi
+jobs:
+  include:
+    - stage: distribute
+      if: branch = master AND type != pull_request
+      install: skip
+      script:
+       - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+       - script/distribute-docker
+       - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then script/distribute-pypi; fi

--- a/script/test
+++ b/script/test
@@ -4,5 +4,11 @@ ARGS="${@:-tests/}"
 set -e
 
 # Run the tests and linting checks
-PYTHONPATH="." pytest -v -s $ARGS
+PYTHONPATH="." pytest --cov=./ -v -s $ARGS
 flake8 --max-line-length 50000 model_converters tests
+
+# Upload coverage for CI.
+if [ -n "$CI" ]; then
+  pip install codecov
+  codecov
+fi

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='model-converters',
-    version='0.0.15',
+    version='0.0.16',
     description='Tools for converting Keras models for use with other ML frameworks.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',

--- a/tests/test_keras_to_tensorflow.py
+++ b/tests/test_keras_to_tensorflow.py
@@ -36,11 +36,7 @@ if sys.version_info[0] == 2:
     MODEL_SERVING_PORTS['nasnet_mobile'] = None
     MODEL_SERVING_PORTS['resnet152'] = None
     MODEL_SERVING_PORTS['inception_resnet_v2'] = None
-# no idea why the Python 3.6 CI won't run these models (they run out of memory)
-if sys.version_info[:2] == (3, 6):
     MODEL_SERVING_PORTS['densenet_169'] = None
-    MODEL_SERVING_PORTS['densenet_201'] = None
-    MODEL_SERVING_PORTS['resnet152'] = None
 
 
 def assert_lists_same_items(list1, list2):


### PR DESCRIPTION
I still have no idea why specific Python versions on Travis run out of memory, it's the same code... Maybe shared nodes or something?