### PR TITLE
Use python -m pip instead

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,13 +4,13 @@ FROM debian:latest
 RUN apt-get -y update && \
     apt-get -y install python-pip python3-pip && \
     apt-get -y clean && \
-    pip2 install --upgrade --upgrade-strategy=eager --no-cache-dir pip stored && \
-    pip3 install --upgrade --upgrade-strategy=eager --no-cache-dir pip stored
+    python2 -m pip install --upgrade --upgrade-strategy=eager --no-cache-dir pip stored && \
+    python3 -m pip install --upgrade --upgrade-strategy=eager --no-cache-dir pip stored
 
 # we install these packages at runtime in the entrypoint, but might as well fetch the latest version into the container
 RUN mkdir /pip && \
-    pip2 download -d /pip tensorflow keras h5py model-converters && \
-    pip3 download -d /pip tensorflow keras h5py model-converters
+    python2 -m pip download -d /pip tensorflow keras h5py model-converters && \
+    python3 -m pip download -d /pip tensorflow keras h5py model-converters
 # note: don't install model-converters here, since it declares a dependency on tensorflow and keras (so those will be installed too)
 #       which is a waste of space since they get reinstalled in the entrypoint
 


### PR DESCRIPTION
~~It seems in v10, pip has moved the location of the main package, see https://github.com/pypa/pip/issues/5240 -- there's really no need to update pip here anyway~~
Reading the linked issue (https://github.com/pypa/pip/issues/5221#issuecomment-382069604), actually it seems using `python -m pip` is a better solution for this.

@amccannv this should fix the issue you were seeing